### PR TITLE
fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ nginxCache.prototype._findFile = function(file, pattern) {
           }
         }
         // Close file descriptor
-        fs.close(fd);
+        fs.close(fd, function() { });
         // Decrement depth counter
         that.depth--;
         if (that.depth === 0) {


### PR DESCRIPTION
(node:13663) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.